### PR TITLE
Bug with Firefox

### DIFF
--- a/css/rs-schedule.css
+++ b/css/rs-schedule.css
@@ -57,7 +57,7 @@
 	width: 12%;
 	text-align: center;
 	vertical-align: top;
-	min-width: 100%;
+	min-width: auto;
 	padding: 0.5em 0;
 }
 


### PR DESCRIPTION
at line60	min-width: 100%;
make the look of the table bad, so i adjust it to 	min-width: auto;
before
https://www.bilder-upload.eu/upload/f1cce3-1586589890.jpg
after
https://www.bilder-upload.eu/upload/bb84c1-1586590029.jpg

testet with crome too look good there too.